### PR TITLE
add: Counted Sendable has conformance when Element is Sendable

### DIFF
--- a/Sources/URLPatterns/Counted.swift
+++ b/Sources/URLPatterns/Counted.swift
@@ -151,3 +151,5 @@ extension Counted: Equatable where Element: Equatable {
         return lhs.elements == rhs.elements
     }
 }
+
+extension Counted: Sendable where Element: Sendable {}


### PR DESCRIPTION
Hi there!
Not sure if this repo is still maintained but I will give a shot 😄 
I've made this update because I'm having compilation issue when storing `Counted` in a static property, my project is using Swift 6 strict concurrency mode.

```swift
 static let myProperty: Counted = .n2(
        "path1",
        "path2"
    )
```

![CleanShot 2025-06-04 at 18 20 40](https://github.com/user-attachments/assets/99836668-a8bd-4d58-b044-481ec219921e)


It could fix it by adding it into my project but I thought it could be nice to have it out of the box from this library.
